### PR TITLE
Msgbuf format not a string

### DIFF
--- a/README
+++ b/README
@@ -1,21 +1,17 @@
 napple1 is an Apple 1 emulator using ncurses, ported from the SDL version 
 Pom1 emulafor. If you have some questions, please report it as an issue. 
 
-How to install on cygwin
-=========================
-0. Setup cygwin (base) and make, gcc4, libncurses-dev
-   and follow Linux procedure. 
+How to install on Ubuntu (ex. Ubuntu 22.04)
+===========================================
+1. sudo apt install make gcc libncurses-dev
 
-How to install on Linux
-========================
-1. Download latest source package nappple1-<n>.<n>.tar.gz 
-   and extract it.
+2. git clone https://github.com/nobuh/napple1.git
 
-2. Build
+3. Build
 	cd napple1/src
 	make
 	cd ..
-3. Run 
+4. Run 
 	./napple1
 
 ROM Directory

--- a/src/msgbuf.c
+++ b/src/msgbuf.c
@@ -45,7 +45,7 @@ void print_msgbuf(char *s)
 			"%-40s", 
 			s);
 	werase(msgbuf);
-	wprintw(msgbuf, msg);
+	wprintw(msgbuf, "%s", msg);
 	wrefresh(msgbuf);
 }
 


### PR DESCRIPTION
fix in make

```
msgbuf.c:48:25: warning: format not a string literal and no format arguments [-Wformat-security]
   48 |         wprintw(msgbuf, msg);
```

and modify README to delete the install instruction for windows cygwin.  